### PR TITLE
change rules for UpdateFilmRequest

### DIFF
--- a/app/Http/Requests/UpdateFilmRequest.php
+++ b/app/Http/Requests/UpdateFilmRequest.php
@@ -23,9 +23,11 @@ class UpdateFilmRequest extends FormRequest
      */
     public function rules()
     {
+        $film = $this->route('film');
+
         return [
-            'nom' => 'required | unique',
-            'auteur' => 'required | min:4',
+            'nom' => 'required|unique:films,nom,' . $film->id,
+            'auteur' => 'required|min:4',
             'genre_id' => 'required'
         ];
     }


### PR DESCRIPTION
if you try to update a film with keeping the same name(nom) , the request will throw an error because of the unique validation  unless you do this